### PR TITLE
Changes missions to planets to keep consistent with respective test 

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ scientist.
 
 If the `Scientist` exists, return JSON data in the format below. **Note**: you will
 need to serialize the data for this response differently than for the
-`GET /scientists` route. Make sure to include an array of missions for each
+`GET /scientists` route. Make sure to include an array of planets for each
 scientist.
 
 ```json


### PR DESCRIPTION
Hi all.

This one fixes the readme to correctly reflect that the Scientist serializer should return its associated planets, instead of missions.