### PR TITLE
Clarify deliverable in README and corresponding spec; add spec for GET /scientists req that lacked coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Add validations to the `Scientist` model:
 Add validations to the `Mission` model:
 
 - must have a `name`, a `scientist` and a `planet`
-- a `scientist` cannot join the same `mission` twice
+- a `scientist` cannot join missions to the same `planet` twice
 
 ## Routes
 

--- a/spec/requests/missions_spec.rb
+++ b/spec/requests/missions_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Missions", type: :request do
     end
 
     context 'with invalid data' do
-      let!(:mission_params) {{name: "Operation Phoenix"}}
+      let!(:mission_params) {{name: "Operation Phoenix", scientist_id: Scientist.first.id, planet_id: Planet.first.id}}
 
       it 'does not creates a new Mission' do
         expect { post '/missions', params: mission_params}.to change(Mission, :count).by(0)

--- a/spec/requests/scientists_spec.rb
+++ b/spec/requests/scientists_spec.rb
@@ -31,6 +31,31 @@ RSpec.describe "Scientists", type: :request do
       ])
     end
 
+    it "does not include associated planet data" do
+      get '/scientists'
+
+      expect(response.body).not_to include_json([
+        {
+          planets: [
+            {
+              id: a_kind_of(Integer),
+              name: "TauCeti E", 
+              distance_from_earth: "12 light years", 
+              nearest_star: "TauCeti", 
+              image: "planet3"
+            },
+            {
+              id: a_kind_of(Integer),
+              name: "Maxxor",
+              distance_from_earth: "9 parsecs", 
+              nearest_star: "Canus Minor", 
+              image: "planet7"
+            }
+          ]
+        }
+      ])
+    end
+
     it 'returns a status of 200 (OK)' do
       get '/scientists'
       expect(response).to have_http_status(:ok)


### PR DESCRIPTION
The deliverable for this requirement was too vague and open to some interpretation (could a scientist visit the same planet more than once as long as the mission names were different?).  This is an attempt to word the intention more clearly and remove the ambiguity.

I also amended the corresponding test in rspec to make sure it's testing the deliverable as now described in the README.